### PR TITLE
Added support for reading INI config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,14 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# List source files & resources
+
+# ============================================
+# Sources and resources
+# ============================================
 file(GLOB_RECURSE Headers *.h *.hpp)
 file(GLOB Sources *.cpp)
-list(APPEND Sources 
-    config/Config.cpp 
+list(APPEND Sources
+    config/Config.cpp
     visualiser/SettingParameter.cpp
     widgets/ClickableLabel.cpp
     widgets/ConfigDetailsDialog.cpp
@@ -24,17 +27,18 @@ file(GLOB UIs *.ui)
 file(GLOB_RECURSE Docs *.md)
 
 
-# Use Qt
-#set(CMAKE_AUTOMOC ON)
-#set(CMAKE_AUTOUIC ON)
+# ============================================
+# Qt setup
+# ============================================
 set(CMAKE_AUTORCC ON)
-#set(CMAKE_AUTOUIC ON)
-
 set(CMAKE_INCLUDE_CURRENT_DIR "YES")
 set(CMAKE_AUTOMOC "YES")
 set(CMAKE_AUTOUIC "YES")
 
-# Find package VTK
+
+# ============================================
+# VTK dependencies
+# ============================================
 find_package(VTK COMPONENTS
     CommonColor
     CommonCore
@@ -53,12 +57,17 @@ find_package(VTK COMPONENTS
         IOLegacy
 )
 
-# Build executable
-add_executable(${PROJECT_NAME} MACOSX_BUNDLE ${Sources} ${Headers} ${Resources} ${UIs} ${Styles} ${Docs} LICENSE)
+
+# ============================================
+# Executable target
+# ============================================
+add_executable(${PROJECT_NAME} MACOSX_BUNDLE
+    ${Sources} ${Headers} ${Resources} ${UIs} ${Styles} ${Docs} LICENSE
+)
 
 
 # ============================================
-# Option to change OOpenCAL directory
+# OOpenCAL include directory (optional)
 # ============================================
 set(OOPENCAL_DIR "/home/dmacri80/Progetto-Visualizer/" CACHE PATH "Path to the base directory of OOpenCAL sources")
 
@@ -70,9 +79,49 @@ else()
 endif()
 
 
+# ============================================
+# inih library (manual integration)
+# ============================================
+# NOTE:
+# The inih library does not provide a CMake build system.
+# It only contains sources and a Meson build definition.
+# Therefore we must manually add the relevant .c/.cpp files
+# and include directories here.
+#
+# Sources:
+#   - ini.c / ini.h   (C parser)
+#   - cpp/INIReader.* (C++ wrapper)
+#
+# We fetch the repository using FetchContent and then
+# register its sources into our target manually.
+include(FetchContent)
+
+FetchContent_Declare(
+    inih
+    GIT_REPOSITORY https://github.com/benhoyt/inih.git
+    GIT_TAG        master
+)
+
+FetchContent_GetProperties(inih)
+if(NOT inih_POPULATED)
+    FetchContent_Populate(inih)
+
+    target_sources(${PROJECT_NAME} PRIVATE
+        ${inih_SOURCE_DIR}/ini.c
+        ${inih_SOURCE_DIR}/cpp/INIReader.cpp
+    )
+    target_include_directories(${PROJECT_NAME} PRIVATE
+        ${inih_SOURCE_DIR}
+        ${inih_SOURCE_DIR}/cpp
+    )
+endif()
+
+
+# ============================================
 # Linking
-#target_link_libraries(${PROJECT_NAME} PRIVATE Qt5::Widgets Qt5::OpenGL VTK::GUISupportQt VTK::IOLegacy)
+# ============================================
 target_link_libraries(${PROJECT_NAME} PRIVATE ${VTK_LIBRARIES})
+#target_link_libraries(${PROJECT_NAME} PRIVATE Qt5::Widgets Qt5::OpenGL VTK::GUISupportQt VTK::IOLegacy)
 
 vtk_module_autoinit(
     TARGETS ${PROJECT_NAME}

--- a/config/Config.h
+++ b/config/Config.h
@@ -19,10 +19,13 @@ public:
     void writeConfigFile() const;
     void readConfigFile();
 
-    ConfigCategory* getConfigCategory(const std::string &name);
+    ConfigCategory* getConfigCategory(const std::string &name, bool ignoreCase = false);
 
     std::vector<std::string> categoryNames() const;
 
 protected:
     void setUpConfigCategories();
+
+    void readConfigFileInOOpenCalFormat();
+    void readConfigFileInIniFormat();
 };


### PR DESCRIPTION
Recently I was proposing to use different format than currently - INI format which is similar to current OOpenCal's format.
In the PR there are two ways of reading config file:
1. OOpenCal's format (as it was before):
```
GENERAL:
	number_of_columns=500
	number_of_rows=500
	number_steps=500
	output_file_name=sciddicaTout
DISTRIBUTED:
	border_size_x=1
	border_size_y=1
	number_node_x=4
	number_node_y=4
LOAD_BALANCING:
	firstLB=101
	stepLB=100
MULTICUDA:
	number_of_gpus_per_node=1
SHARED:
	chunk_size=5
```
2. INI format with https://github.com/benhoyt/inih library (BSD Licence):
```
[GENERAL]
number_of_columns=500
number_of_rows=500
number_steps=500
output_file_name=sciddicaTout

[DISTRIBUTED]
border_size_x=1
border_size_y=1
number_node_x=4
number_node_y=4

[LOAD_BALANCING]
firstLB=101
stepLB=100

[MULTICUDA]
number_of_gpus_per_node=1

[SHARED]
chunk_size=5
```
**Note:**
The library is being downloaded in `CMakeLists.txt`, so it does not requires to install any dependencies manually.

