### PR TITLE
[Refactoring] Separation of Visualiser: into ModelReader and Visualiser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ file(GLOB_RECURSE Headers *.h *.hpp)
 file(GLOB Sources *.cpp)
 list(APPEND Sources
     config/Config.cpp
+    config/ConfigCategory.cpp
     visualiser/SettingParameter.cpp
     visualiser/VideoExporter.cpp
     visualiser/Visualiser.cpp

--- a/ModelReader.cpp
+++ b/ModelReader.cpp
@@ -22,7 +22,7 @@ ColumnAndRow ReaderHelpers::getColumnAndRowFromLine(const std::string& line)
         };
 }
 
-std::pair<int,int> ReaderHelpers::calculateXYOffset(NodeIndex node, int nNodeX, int nNodeY, const std::vector<int>& allLocalCols, const std::vector<int>& allLocalRows)
+std::pair<int,int> ReaderHelpers::calculateXYOffset(NodeIndex node, int nNodeX, int nNodeY, const std::vector<ColumnAndRow>& columnsAndRows)
 {
     int offsetX = 0; //= //(node % nNodeX)*nLocalCols;//-this->borderSizeX;
     int offsetY = 0; //= //(node / nNodeX)*nLocalRows;//-this->borderSizeY;
@@ -31,14 +31,14 @@ std::pair<int,int> ReaderHelpers::calculateXYOffset(NodeIndex node, int nNodeX, 
     {
         for (int k = 0; k < node % nNodeX; k++)
         {
-            offsetX += allLocalCols[k];
+            offsetX += columnsAndRows[k].column;
         }
     }
     else
     {
         for (int k = (node / nNodeX) * nNodeX; k < node; k++)
         {
-            offsetX += allLocalCols[k];
+            offsetX += columnsAndRows[k].column;
         }
     }
 
@@ -46,7 +46,7 @@ std::pair<int,int> ReaderHelpers::calculateXYOffset(NodeIndex node, int nNodeX, 
     {
         for (int k = node - nNodeX; k >= 0;)
         {
-            offsetY += allLocalRows[k];
+            offsetY += columnsAndRows[k].row;
             k -= nNodeX;
         }
     }

--- a/ModelReader.cpp
+++ b/ModelReader.cpp
@@ -1,0 +1,54 @@
+#include "ModelReader.hpp"
+
+
+ColumnAndRow ReaderHelpers::getColumnAndRowFromLine(const std::string& line)
+{
+    /// input format: "C-R" where C and R are numbers
+    if (line.empty())
+    {
+        throw std::invalid_argument("Line is empty, but it should contain columns and row!");
+    }
+
+    const auto delimiterPos = line.find('-');
+    if (delimiterPos == std::string::npos)
+    {
+        throw std::runtime_error("No delimiter '-' found in the line: >" + line + "<");
+    }
+
+    return ColumnAndRow
+        {
+            .column = std::stoi(line.substr(0, delimiterPos)),
+            .row = std::stoi(line.substr(delimiterPos + 1))
+        };
+}
+
+std::pair<int,int> ReaderHelpers::calculateXYOffset(NodeIndex node, int nNodeX, int nNodeY, const std::vector<int>& allLocalCols, const std::vector<int>& allLocalRows)
+{
+    int offsetX = 0; //= //(node % nNodeX)*nLocalCols;//-this->borderSizeX;
+    int offsetY = 0; //= //(node / nNodeX)*nLocalRows;//-this->borderSizeY;
+
+    if (nNodeY == 1)
+    {
+        for (int k = 0; k < node % nNodeX; k++)
+        {
+            offsetX += allLocalCols[k];
+        }
+    }
+    else
+    {
+        for (int k = (node / nNodeX) * nNodeX; k < node; k++)
+        {
+            offsetX += allLocalCols[k];
+        }
+    }
+
+    if (node >= nNodeX)
+    {
+        for (int k = node - nNodeX; k >= 0;)
+        {
+            offsetY += allLocalRows[k];
+            k -= nNodeX;
+        }
+    }
+    return {offsetX, offsetY};
+}

--- a/ModelReader.cpp
+++ b/ModelReader.cpp
@@ -22,7 +22,7 @@ ColumnAndRow ReaderHelpers::getColumnAndRowFromLine(const std::string& line)
         };
 }
 
-std::pair<int,int> ReaderHelpers::calculateXYOffset(NodeIndex node, int nNodeX, int nNodeY, const std::vector<ColumnAndRow>& columnsAndRows)
+ColumnAndRow ReaderHelpers::calculateXYOffset(NodeIndex node, int nNodeX, int nNodeY, const std::vector<ColumnAndRow>& columnsAndRows)
 {
     int offsetX = 0; //= //(node % nNodeX)*nLocalCols;//-this->borderSizeX;
     int offsetY = 0; //= //(node / nNodeX)*nLocalRows;//-this->borderSizeY;
@@ -50,5 +50,5 @@ std::pair<int,int> ReaderHelpers::calculateXYOffset(NodeIndex node, int nNodeX, 
             k -= nNodeX;
         }
     }
-    return {offsetX, offsetY};
+    return ColumnAndRow::xy(offsetX, offsetY);
 }

--- a/ModelReader.hpp
+++ b/ModelReader.hpp
@@ -22,6 +22,27 @@ public:
         stage.resize(nNodeX * nNodeY);
     }
 
+    template<class Matrix>
+    void readStageStateFromFilesForStep(Matrix& m, SettingParameter* sp, Line *lines);
+
+    /** @brief Loads data into hashMap from text files.
+     *
+     * Expected file format (each line):
+     *     <stepNumber:int> <positionInFile:long>
+     *
+     * Example:
+     *     0 37
+     *     1 32504
+     *     2 64971
+     *
+     * Each line must contain exactly two numbers separated by whitespace.
+     *
+     * @param nNodeX number of nodes along the X axis
+     * @param nNodeY number of nodes along the Y axis
+     * @param filename base filename (e.g., "ball"), for which nodes files are being read */
+    void readStepsOffsetsForAllNodesFromFiles(NodeIndex nNodeX, NodeIndex nNodeY, const std::string &filename);
+
+private:
     FilePosition getStepStartingPositionInFile(StepIndex step, NodeIndex node)
     {
         return stage.at(node).at(step);
@@ -45,27 +66,6 @@ public:
 
     [[nodiscard]] ColumnAndRow readColumnAndRowForStepFromFile(StepIndex step, const std::string& fileName, NodeIndex node);
 
-    template<class Matrix>
-    void readStageStateFromFilesForStep(Matrix& m, SettingParameter* sp, Line *lines);
-
-    /** @brief Loads data into hashMap from text files.
-     *
-     * Expected file format (each line):
-     *     <stepNumber:int> <positionInFile:long>
-     *
-     * Example:
-     *     0 37
-     *     1 32504
-     *     2 64971
-     *
-     * Each line must contain exactly two numbers separated by whitespace.
-     *
-     * @param nNodeX number of nodes along the X axis
-     * @param nNodeY number of nodes along the Y axis
-     * @param filename base filename (e.g., "ball"), for which nodes files are being read */
-    void readStepsOffsetsForAllNodesFromFiles(NodeIndex nNodeX, NodeIndex nNodeY, const std::string &filename);
-
-private:
     std::pair<std::vector<StepIndex>, std::vector<StepIndex>> giveMeLocalColsAndRowsForAllSteps(StepIndex step, int nNodeX, int nNodeY, const std::string& fileName);
 };
 

--- a/ModelReader.hpp
+++ b/ModelReader.hpp
@@ -14,16 +14,17 @@
 template <class Cell>
 class ModelReader
 {
-    std::vector<std::unordered_map<StepIndex, FilePosition>> hashMap;
+    std::vector<std::unordered_map<StepIndex, FilePosition>> stage;
+
 public:
-    void prepareHashMap(NodeIndex nNodeX, NodeIndex nNodeY)
+    void prepareStage(NodeIndex nNodeX, NodeIndex nNodeY)
     {
-        hashMap.resize(nNodeX * nNodeY);
+        stage.resize(nNodeX * nNodeY);
     }
 
     FilePosition getStepStartingPositionInFile(StepIndex step, NodeIndex node)
     {
-        return hashMap.at(node).at(step);
+        return stage.at(node).at(step);
     }
 
     /** @brief Opens the data file for a given simulation step and node.
@@ -231,7 +232,7 @@ void ModelReader<T>::readStepsOffsetsForAllNodesFromFiles(NodeIndex nNodeX, Node
                     throw std::runtime_error("Invalid line format in file: " + fileNameIndex);
             }
 
-            const auto [it, inserted] = hashMap[node].emplace(stepNumber, positionInFile);
+            const auto [it, inserted] = stage[node].emplace(stepNumber, positionInFile);
             if (! inserted)
             {
                 std::cerr << std::format("Duplicate stepNumber {} found in file '{}' (node {})", stepNumber, fileNameIndex, node) << std::endl;

--- a/ModelReader.hpp
+++ b/ModelReader.hpp
@@ -1,0 +1,241 @@
+#pragma once
+#include <vector>
+#include <unordered_map>
+#include <iostream>
+#include <fstream>
+#include <climits> // INT_MAX
+#include <cmath> // log10
+#include <filesystem>
+#include "types.h"
+#include "visualiser/SettingParameter.h"
+#include "visualiser/Line.h"
+
+
+template <class Cell>
+class ModelReader
+{
+    std::vector<std::unordered_map<StepIndex, FilePosition>> hashMap;
+public:
+    void prepareHashMap(NodeIndex nNodeX, NodeIndex nNodeY)
+    {
+        hashMap.resize(nNodeX * nNodeY);
+    }
+
+    FilePosition getStepStartingPositionInFile(StepIndex step, NodeIndex node)
+    {
+        return hashMap.at(node).at(step);
+    }
+
+    /** @brief Opens the data file for a given simulation step and node.
+     *
+     * The function locates the correct file for the specified node (e.g. "ball3.txt", where 3 is node number),
+     * seeks to the byte position corresponding to the given simulation step in file,
+     * reads the first header line containing local grid dimensions (columns and rows),
+     * and returns an input file stream positioned right after that header.
+     *
+     * @param step         Simulation step number.
+     * @param fileName     Base file name (without node index or extension).
+     * @param node         Node index for which data should be opened.
+     * @param columnAndRow Output: number of local columns and rows read from header line.
+     *
+     * @return std::ifstream Stream ready for reading cell data of this node at given step.
+     * @throws std::runtime_error If the file cannot be opened, seek fails, or header is invalid. */
+    [[nodiscard]] std::ifstream readColumnAndRowForStepFromFileReturningStream(StepIndex step, const std::string& fileName, NodeIndex node, ColumnAndRow& columnAndRow);
+
+    [[nodiscard]] ColumnAndRow readColumnAndRowForStepFromFile(StepIndex step, const std::string& fileName, NodeIndex node);
+
+    template<class Matrix>
+    void readStageStateFromFilesForStep(Matrix& m, SettingParameter* sp, Line *lines);
+
+    /** @brief Loads data into hashMap from text files.
+     *
+     * Expected file format (each line):
+     *     <stepNumber:int> <positionInFile:long>
+     *
+     * Example:
+     *     0 37
+     *     1 32504
+     *     2 64971
+     *
+     * Each line must contain exactly two numbers separated by whitespace.
+     *
+     * @param nNodeX number of nodes along the X axis
+     * @param nNodeY number of nodes along the Y axis
+     * @param filename base filename (e.g., "ball"), for which nodes files are being read */
+    void readStepsOffsetsForAllNodesFromFiles(NodeIndex nNodeX, NodeIndex nNodeY, const std::string &filename);
+
+private:
+    std::pair<std::vector<StepIndex>, std::vector<StepIndex>> giveMeLocalColsAndRowsForAllSteps(StepIndex step, int nNodeX, int nNodeY, const std::string& fileName);
+};
+
+/////////////////////////////
+namespace ReaderHelpers /// functions which are not templates
+{
+[[nodiscard]] inline std::string giveMeFileName(const std::string& fileName, NodeIndex node)
+{
+    return std::format("{}{}.txt", fileName, node);
+}
+[[nodiscard]] inline std::string giveMeFileNameIndex(const std::string &fileName, NodeIndex node)
+{
+    return std::format("{}{}_index.txt", fileName, node);
+}
+
+ColumnAndRow getColumnAndRowFromLine(const std::string& line);
+
+std::pair<int,int> calculateXYOffset(NodeIndex node, int nNodeX, int nNodeY, const std::vector<int>& allLocalCols, const std::vector<int>& allLocalRows);
+}
+/////////////////////////////
+
+template <class T>
+ColumnAndRow ModelReader<T>::readColumnAndRowForStepFromFile(StepIndex step, const std::string& fileName, NodeIndex node)
+{
+    ColumnAndRow columnAndRow;
+    std::ifstream file = readColumnAndRowForStepFromFileReturningStream(step, fileName, node, columnAndRow);
+    return columnAndRow;
+}
+template <class T>
+std::ifstream ModelReader<T>::readColumnAndRowForStepFromFileReturningStream(StepIndex step, const std::string& fileName, NodeIndex node, ColumnAndRow &columnAndRow)
+{
+    const auto fileNameTmp = ReaderHelpers::giveMeFileName(fileName, node);
+
+    std::ifstream file(fileNameTmp);
+    if (! file.is_open())
+    {
+        throw std::runtime_error(std::format("Can't read '{}' in {} function", fileNameTmp, __func__));
+    }
+
+    const auto fPos = getStepStartingPositionInFile(step, node);
+    file.seekg(fPos);
+    if (! file)
+    {
+        throw std::runtime_error(std::format("Seek failed in '{}' at position {}", fileNameTmp, fPos));
+    }
+
+    std::string line;
+    if (! std::getline(file, line))
+    {
+        throw std::runtime_error(std::format("Failed to read line from '{}' at position {}", fileNameTmp, fPos));
+    }
+
+    columnAndRow = ReaderHelpers::getColumnAndRowFromLine(line);
+    return file;
+}
+
+template<class T>
+template<class Matrix>
+void ModelReader<T>::readStageStateFromFilesForStep(Matrix& m, SettingParameter* sp, Line *lines)
+{
+    const auto [allLocalCols, allLocalRows] = giveMeLocalColsAndRowsForAllSteps(sp->step, sp->nNodeX, sp->nNodeY, sp->outputFileName);
+
+    bool startStepDone = false;
+
+    constexpr std::size_t numbersPerLine = 10'000;
+    const std::size_t lineBufferSize = (log10(UINT_MAX) + 2) * numbersPerLine;
+    std::string line;
+    line.reserve(lineBufferSize); /// for speedup to avoid realocations
+
+    for (NodeIndex node = 0; node < sp->nNodeX * sp->nNodeY; ++node)
+    {
+        const auto [offsetX, offsetY] = ReaderHelpers::calculateXYOffset(node, sp->nNodeX, sp->nNodeY, allLocalCols, allLocalRows);
+
+        ColumnAndRow columnAndRow;
+        std::ifstream fp = readColumnAndRowForStepFromFileReturningStream(sp->step, sp->outputFileName, node, columnAndRow);
+        if (! fp)
+            throw std::runtime_error("Cannot open file for node " + std::to_string(node));
+
+        /// introducing big buffer for reading (for speed up)
+        static thread_local char fileBuffer[1 << 16];
+        fp.rdbuf()->pubsetbuf(fileBuffer, sizeof(fileBuffer));
+
+        lines[node * 2]     = Line(offsetX, offsetY, offsetX + columnAndRow.column, offsetY);
+        lines[node * 2 + 1] = Line(offsetX, offsetY, offsetX, offsetY + columnAndRow.row);
+
+        for (int row = 0; row < columnAndRow.row; ++row)
+        {
+            if (! std::getline(fp, line))
+            {
+                const auto fileNameTmp = ReaderHelpers::giveMeFileName(sp->outputFileName, node);
+                throw std::runtime_error("Error when reading entire line of file " + fileNameTmp);
+            }
+
+            std::replace(begin(line), end(line), ' ', '\0'); /// this is faster than using std::ranges::replace
+
+            /// Moving through tokens (token are characters ended with '0')
+            char* currentTokenPtr = line.data();
+            for (int col = 0; col < columnAndRow.column && *currentTokenPtr; ++col)
+            {
+                if (! startStepDone) [[unlikely]]
+                {
+                    m[row + offsetY][col + offsetX].T::startStep(sp->step);
+                    startStepDone = true;
+                }
+
+                m[row + offsetY][col + offsetX].T::composeElement(currentTokenPtr);
+
+                /// go to another token
+                while (*currentTokenPtr)
+                    ++currentTokenPtr;
+                ++currentTokenPtr; /// skip '\0'
+            }
+        }
+    }
+}
+template<class T>
+std::pair<std::vector<StepIndex>, std::vector<StepIndex>> ModelReader<T>::giveMeLocalColsAndRowsForAllSteps(StepIndex step, int nNodeX, int nNodeY, const std::string& fileName)
+{
+    const auto nodesCount = nNodeX * nNodeY;
+    std::vector<StepIndex> allLocalCols{nodesCount}, allLocalRows{nodesCount};
+    allLocalCols.resize(nodesCount);
+    allLocalRows.resize(nodesCount);
+
+    for (NodeIndex node = 0; node < nodesCount; node++)
+    {
+        auto [nLocalCols, nLocalRows] = readColumnAndRowForStepFromFile(step, fileName, node);
+
+        allLocalCols[node] = nLocalCols;
+        allLocalRows[node] = nLocalRows;
+    }
+    return {allLocalCols, allLocalRows};
+}
+
+template <class T>
+void ModelReader<T>::readStepsOffsetsForAllNodesFromFiles(NodeIndex nNodeX, NodeIndex nNodeY, const std::string& filename)
+{
+    const auto totalNodes = nNodeX * nNodeY;
+    for (NodeIndex node = 0; node < totalNodes; ++node)
+    {
+        const auto fileNameIndex = ReaderHelpers::giveMeFileNameIndex(filename, node);
+        std::cout << "Reading file: " << fileNameIndex << '\n';
+
+        if (! std::filesystem::exists(fileNameIndex))
+        {
+            throw std::runtime_error("File not found: " + fileNameIndex);
+        }
+
+        std::ifstream file(fileNameIndex);
+        if (! file)
+        {
+            throw std::runtime_error("Cannot open file: " + fileNameIndex);
+        }
+
+        while (true)
+        {
+            StepIndex stepNumber;
+            FilePosition positionInFile;
+
+            if (! (file >> stepNumber >> positionInFile))
+            { /// enters here if reading error
+                if (file.eof())
+                    break;
+                else
+                    throw std::runtime_error("Invalid line format in file: " + fileNameIndex);
+            }
+
+            const auto [it, inserted] = hashMap[node].emplace(stepNumber, positionInFile);
+            if (! inserted)
+            {
+                std::cerr << std::format("Duplicate stepNumber {} found in file '{}' (node {})", stepNumber, fileNameIndex, node) << std::endl;
+            }
+        }
+    }
+}

--- a/config/ConfigCategory.cpp
+++ b/config/ConfigCategory.cpp
@@ -1,0 +1,18 @@
+#include <algorithm>
+#include "ConfigCategory.h"
+
+
+ConfigParameter *ConfigCategory::getConfigParameter(const std::string &paramName)
+{
+    auto it = std::find_if(configParameters.begin(), configParameters.end(),
+                           [&](const ConfigParameter& p) { return p.getName() == paramName; });
+    return (it != configParameters.end()) ? &*it : nullptr;
+}
+
+void ConfigCategory::setConfigParameterValue(const std::string &paramName, const std::string &value)
+{
+    if (auto* configParameter = getConfigParameter(paramName))
+    {
+        configParameter->setDefaultValue(value);
+    }
+}

--- a/config/ConfigCategory.h
+++ b/config/ConfigCategory.h
@@ -16,7 +16,7 @@ public:
         : name{std::move(name)}, configParameters{std::move(params)}
     {}
 
-    void readFile(char* /*name*/, char* /*configuration_path*/)
+    void readFile(const char* /*name*/, const char* /*configuration_path*/)
     {
         #warning "Ask Alessio or Andrea about the function - how it should be implemented, or should it be removed?"
     }

--- a/config/ConfigCategory.h
+++ b/config/ConfigCategory.h
@@ -2,7 +2,6 @@
 
 #include <string>
 #include <vector>
-#include <algorithm>
 #include "ConfigParameter.h"
 
 
@@ -41,20 +40,9 @@ public:
         return configParameters;
     }
 
-    ConfigParameter* getConfigParameter(const std::string& paramName)
-    {
-        auto it = std::find_if(configParameters.begin(), configParameters.end(),
-                               [&](const ConfigParameter& p) { return p.getName() == paramName; });
-        return (it != configParameters.end()) ? &*it : nullptr;
-    }
+    ConfigParameter* getConfigParameter(const std::string& paramName);
 
-    void setConfigParameterValue(const std::string& paramName, const std::string& value)
-    {
-        if (auto* configParameter = getConfigParameter(paramName))
-        {
-            configParameter->setDefaultValue(value);
-        }
-    }
+    void setConfigParameterValue(const std::string& paramName, const std::string& value);
 
     bool operator==(const std::string& name) const
     {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -79,13 +79,6 @@ void MainWindow::configureButton(QPushButton* button, QStyle::StandardPixmap ico
     button->setStyleSheet(NULL);
 }
 
-void MainWindow::configureCursorPosition()
-{
-    ui->updatePositionSlider->setMinimum(FIRST_STEP_NUMBER);
-    ui->updatePositionSlider->setMaximum(100);
-    ui->updatePositionSlider->setValue(FIRST_STEP_NUMBER);
-}
-
 
 void MainWindow::showInputFilePathOnBarLabel(const QString& inputFilePath)
 {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -17,11 +17,11 @@
 
 namespace
 {
-constexpr int FIRST_STEP_NUMBER = 1;
+constexpr int FIRST_STEP_NUMBER = 0;
 }
 
 
-MainWindow::MainWindow(const QString& configFileName, QWidget* parent) : QMainWindow(nullptr), ui(new Ui::MainWindow)
+MainWindow::MainWindow(const QString& configFileName, QWidget* parent) : QMainWindow(nullptr), ui(new Ui::MainWindow), currentStep{FIRST_STEP_NUMBER}
 {
     ui->setupUi(this);
     setWindowTitle(QApplication::applicationName());
@@ -94,7 +94,7 @@ void MainWindow::showInputFilePathOnBarLabel(const QString& inputFilePath)
 
 void MainWindow::initializeSceneWidget(const QString& configFileName)
 {
-    ui->sceneWidget->addVisualizer(configFileName.toStdString());
+    ui->sceneWidget->addVisualizer(configFileName.toStdString(), currentStep);
 }
 
 void MainWindow::setTotalStepsFromConfiguration(const QString &configurationFile)

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -65,6 +65,7 @@ void MainWindow::configureButtons()
     configureButton(ui->rightButton, QStyle::SP_ArrowRight);
     configureButton(ui->leftButton, QStyle::SP_ArrowLeft);
     configureButton(ui->skipForwardButton, QStyle::SP_MediaSkipForward);
+    configureButton(ui->skipBackwardButton, QStyle::SP_MediaSkipBackward);
     configureButton(ui->playButton, QStyle::SP_MediaPlay);
     configureButton(ui->stopButton, QStyle::SP_MediaStop);
     configureButton(ui->backButton, QStyle::SP_MediaSeekBackward);
@@ -124,6 +125,7 @@ void MainWindow::connectButtons()
     connect(ui->playButton, &QPushButton::clicked, this, &MainWindow::onPlayButtonClicked);
     connect(ui->stopButton, &QPushButton::clicked, this, &MainWindow::onStopButtonClicked);
     connect(ui->skipForwardButton, &QPushButton::clicked, this, &MainWindow::onSkipForwardButtonClicked);
+    connect(ui->skipBackwardButton, &QPushButton::clicked, this, &MainWindow::onSkipBackwardButtonClicked);
     connect(ui->backButton, &QPushButton::clicked, this, &MainWindow::onBackButtonClicked);
     connect(ui->leftButton, &QPushButton::clicked, this, &MainWindow::onLeftButtonClicked);
     connect(ui->rightButton, &QPushButton::clicked, this, &MainWindow::onRightButtonClicked);
@@ -317,6 +319,12 @@ void MainWindow::onSkipForwardButtonClicked()
     setPositionOnWidgets(currentStep);
 }
 
+void MainWindow::onSkipBackwardButtonClicked()
+{
+    currentStep = FIRST_STEP_NUMBER;
+    setPositionOnWidgets(currentStep);
+}
+
 void MainWindow::onBackButtonClicked()
 {
     isPlaying = true;
@@ -357,22 +365,23 @@ void MainWindow::setPositionOnWidgets(int stepPosition, bool updateSlider)
         }
         ui->positionSpinBox->setValue(stepPosition);
         ui->sceneWidget->selectedStepParameter(stepPosition);
-
-        changeWhichButtonsAreEnabled();
     }
     catch (const std::exception& e)
     {
         QMessageBox::warning(this, "Changing position error",
                              tr("It was impossible to change position, because:\n") + e.what());
     }
+    changeWhichButtonsAreEnabled();
 }
 
 void MainWindow::changeWhichButtonsAreEnabled()
 {
     ui->rightButton->setDisabled(currentStep == totalSteps());
     ui->playButton->setDisabled(currentStep == totalSteps());
-    ui->leftButton->setDisabled(currentStep <= 1);
-    ui->backButton->setDisabled(currentStep <= 1);
+    ui->leftButton->setDisabled(currentStep <= FIRST_STEP_NUMBER);
+    ui->backButton->setDisabled(currentStep <= FIRST_STEP_NUMBER);
+    ui->skipBackwardButton->setDisabled(currentStep <= FIRST_STEP_NUMBER);
+    ui->skipForwardButton->setDisabled(currentStep == totalSteps());
 }
 
 void MainWindow::onStepNumberChanged()

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -28,6 +28,7 @@ private slots:
     void onPlayButtonClicked();
     void onStopButtonClicked();
     void onSkipForwardButtonClicked();
+    void onSkipBackwardButtonClicked();
     void onBackButtonClicked();
     void onLeftButtonClicked();
     void onRightButtonClicked();

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -69,7 +69,7 @@ private:
 
     Ui::MainWindow* ui;
 
-    int currentStep = 1;
+    int currentStep;
     bool isPlaying = false;
     bool isBacking = false;
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -48,7 +48,6 @@ private:
     void setupConnections();
     void configureButtons();
     void configureButton(QPushButton* button, QStyle::StandardPixmap icon);
-    void configureCursorPosition();
     void initializeSceneWidget(const QString& configFileName);
     void setTotalStepsFromConfiguration(const QString& configurationFile);
     void connectButtons();

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -49,6 +49,16 @@
        <number>5</number>
       </property>
       <item>
+       <widget class="QPushButton" name="skipBackwardButton">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="icon">
+         <iconset theme="QIcon::ThemeIcon::MediaSkipBackward"/>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QPushButton" name="skipForwardButton">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -89,7 +89,7 @@
          <string>step: </string>
         </property>
         <property name="minimum">
-         <number>1</number>
+         <number>0</number>
         </property>
        </widget>
       </item>
@@ -306,10 +306,13 @@
          <string>Position</string>
         </property>
         <property name="minimum">
-         <number>1</number>
+         <number>0</number>
         </property>
         <property name="maximum">
          <number>100</number>
+        </property>
+        <property name="value">
+         <number>0</number>
         </property>
         <property name="orientation">
          <enum>Qt::Orientation::Horizontal</enum>

--- a/types.h
+++ b/types.h
@@ -3,3 +3,10 @@
 using StepIndex = int;
 using NodeIndex = int;
 using FilePosition = long long;
+
+struct ColumnAndRow
+{
+    using CoordinateType = int;
+    CoordinateType column;
+    CoordinateType row;
+};

--- a/types.h
+++ b/types.h
@@ -1,3 +1,5 @@
 #pragma once
 
 using StepIndex = int;
+using NodeIndex = int;
+using FilePosition = long long;

--- a/types.h
+++ b/types.h
@@ -1,0 +1,3 @@
+#pragma once
+
+using StepIndex = int;

--- a/types.h
+++ b/types.h
@@ -7,6 +7,21 @@ using FilePosition = long long;
 struct ColumnAndRow
 {
     using CoordinateType = int;
+
     CoordinateType column;
     CoordinateType row;
+
+    static ColumnAndRow xy(CoordinateType x, CoordinateType y)
+    {
+        return ColumnAndRow {.column=x, .row=y};
+    }
+
+    auto x() const
+    {
+        return column;
+    }
+    auto y() const
+    {
+        return row;
+    }
 };

--- a/visualiser/SettingParameter.cpp
+++ b/visualiser/SettingParameter.cpp
@@ -4,8 +4,8 @@
 std::ostream& operator<<(std::ostream& os, const SettingParameter& sp)
 {
     os << "SettingParameter{"
-       << "dimX=" << sp.dimX << ", "
-       << "dimY=" << sp.dimY << ", "
+       << "numberOfColumnX=" << sp.numberOfColumnX << ", "
+       << "numberOfRowsY=" << sp.numberOfRowsY << ", "
        << "nNodeX=" << sp.nNodeX << ", "
        << "nNodeY=" << sp.nNodeY << ", "
        << "outputFileName=" << sp.outputFileName << "}";

--- a/visualiser/SettingParameter.h
+++ b/visualiser/SettingParameter.h
@@ -8,8 +8,8 @@ struct SettingParameter
 {
     StepIndex step;
     StepIndex nsteps;
-    int dimX;
-    int dimY;
+    int numberOfColumnX;
+    int numberOfRowsY;
     int nNodeX;
     int nNodeY;
     int numberOfLines;

--- a/visualiser/SettingParameter.h
+++ b/visualiser/SettingParameter.h
@@ -2,22 +2,22 @@
 
 #include <iosfwd>
 #include <string>
-
+#include "types.h"
 
 struct SettingParameter
 {
-    int step;
-    int nsteps;
-    bool changed;
-    bool firstTime;
-    bool insertAction; // TOO: GB: Not read anywhere, just set
+    StepIndex step;
+    StepIndex nsteps;
     int dimX;
     int dimY;
     int nNodeX;
     int nNodeY;
-    std::string outputFileName;
     int numberOfLines;
-    const int font_size = 18;
+    std::string outputFileName;
+    static constexpr int font_size = 18;
+    bool changed;
+    bool firstTime;
+    bool insertAction; // TOO: GB: Not read anywhere, just set
 
     friend std::ostream& operator<<(std::ostream& os, const SettingParameter& sp);
 };

--- a/visualiser/Visualiser.cpp
+++ b/visualiser/Visualiser.cpp
@@ -1,7 +1,7 @@
 #include "visualiser/Visualizer.hpp"
 
 
-std::pair<int,int> VisualiserHelpers::getColumnAndRowFromLine(const std::string& line)
+ColumnAndRow VisualiserHelpers::getColumnAndRowFromLine(const std::string& line)
 {
     /// input format: "C-R" where C and R are numbers
     if (line.empty())
@@ -15,10 +15,11 @@ std::pair<int,int> VisualiserHelpers::getColumnAndRowFromLine(const std::string&
         throw std::runtime_error("No delimiter '-' found in the line: >" + line + "<");
     }
 
-    auto nLocalCols = std::stoi(line.substr(0, delimiterPos));
-    auto nLocalRows = std::stoi(line.substr(delimiterPos + 1));
-
-    return {nLocalCols, nLocalRows};
+    return ColumnAndRow
+    {
+        .column = std::stoi(line.substr(0, delimiterPos)),
+        .row = std::stoi(line.substr(delimiterPos + 1))
+    };
 }
 
 std::pair<int,int> VisualiserHelpers::calculateXYOffset(NodeIndex node, int nNodeX, int nNodeY, const std::vector<int>& allLocalCols, const std::vector<int>& allLocalRows)

--- a/visualiser/Visualiser.cpp
+++ b/visualiser/Visualiser.cpp
@@ -1,54 +1,100 @@
 #include "visualiser/Visualizer.hpp"
+#include "Line.h"
 
 
-ColumnAndRow VisualiserHelpers::getColumnAndRowFromLine(const std::string& line)
+void Visualizer::buildLoadBalanceLine(Line *lines, int dimLines,int nCols, int nRows, vtkSmartPointer<vtkPoints> pts, vtkSmartPointer<vtkCellArray> cellLines, vtkSmartPointer<vtkPolyData> grid, vtkSmartPointer<vtkNamedColors> colors, vtkSmartPointer<vtkRenderer> renderer,vtkSmartPointer<vtkActor2D> actorBuildLine)
 {
-    /// input format: "C-R" where C and R are numbers
-    if (line.empty())
+    for (int i = 0; i < dimLines; i++)
     {
-        throw std::invalid_argument("Line is empty, but it should contain columns and row!");
+        std::cout << "Line (" << lines[i].x1 << ", " << lines[i].y1 << ") -> (" <<lines[i].x2 << ", " <<lines[i].y2 << ")" << std::endl;
+        pts->InsertNextPoint(lines[i].x1 * 1, nCols-1-lines[i].y1 * 1, 0.0);
+        pts->InsertNextPoint(lines[i].x2 * 1, nCols-1-lines[i].y2 * 1, 0.0);
+        cellLines->InsertNextCell(2);
+        cellLines->InsertCellPoint(i*2);
+        cellLines->InsertCellPoint(i*2+1);
     }
 
-    const auto delimiterPos = line.find('-');
-    if (delimiterPos == std::string::npos)
-    {
-        throw std::runtime_error("No delimiter '-' found in the line: >" + line + "<");
-    }
+    grid->SetPoints(pts);
+    grid->SetLines(cellLines);
+    // Set up the coordinate system.
+    vtkNew<vtkCoordinate> normCoords;
+    normCoords->SetCoordinateSystemToWorld();
 
-    return ColumnAndRow
-    {
-        .column = std::stoi(line.substr(0, delimiterPos)),
-        .row = std::stoi(line.substr(delimiterPos + 1))
-    };
+    vtkNew<vtkPolyDataMapper2D> mapper;
+    mapper->SetInputData(grid);
+    mapper->Update();
+    mapper->SetTransformCoordinate(normCoords);
+
+    actorBuildLine->SetMapper(mapper);
+    actorBuildLine->GetMapper()->Update();
+    actorBuildLine->GetProperty()->SetColor(colors->GetColor3d("Red").GetData());
+    // actorBuildLine->GetProperty()->SetLineWidth(1.5);
+    renderer->AddActor2D(actorBuildLine);
 }
 
-std::pair<int,int> VisualiserHelpers::calculateXYOffset(NodeIndex node, int nNodeX, int nNodeY, const std::vector<int>& allLocalCols, const std::vector<int>& allLocalRows)
+void Visualizer::refreshBuildLoadBalanceLine(Line *lines, int dimLines,int nCols,int nRows, vtkActor2D* lineActor,vtkSmartPointer<vtkNamedColors> colors)
 {
-    int offsetX = 0; //= //(node % nNodeX)*nLocalCols;//-this->borderSizeX;
-    int offsetY = 0; //= //(node / nNodeX)*nLocalRows;//-this->borderSizeY;
+    vtkPolyDataMapper2D* mapper = (vtkPolyDataMapper2D*) lineActor->GetMapper();
+    mapper->Update();
+    vtkNew<vtkPolyData> grid;
+    vtkNew<vtkPoints> pts;
+    vtkNew<vtkCellArray> cellLines;
 
-    if (nNodeY == 1)
+    for (int i = 0; i < dimLines; i++)
     {
-        for (int k = 0; k < node % nNodeX; k++)
-        {
-            offsetX += allLocalCols[k];
-        }
-    }
-    else
-    {
-        for (int k = (node / nNodeX) * nNodeX; k < node; k++)
-        {
-            offsetX += allLocalCols[k];
-        }
+        pts->InsertNextPoint((lines[i].x1 * 1), ( nCols-1-lines[i].y1 * 1), 0.0);
+        pts->InsertNextPoint((lines[i].x2 * 1), ( nCols-1-lines[i].y2 * 1), 0.0);
+        cellLines->InsertNextCell(2);
+        cellLines->InsertCellPoint(i*2);
+        cellLines->InsertCellPoint(i*2+1);
     }
 
-    if (node >= nNodeX)
-    {
-        for (int k = node - nNodeX; k >= 0;)
-        {
-            offsetY += allLocalRows[k];
-            k -= nNodeX;
-        }
-    }
-    return {offsetX, offsetY};
+    grid->SetPoints(pts);
+    grid->SetLines(cellLines);
+    // Set up the coordinate system.
+    vtkNew<vtkCoordinate> normCoords;
+    normCoords->SetCoordinateSystemToWorld();
+
+    mapper->SetInputData(grid);
+    mapper->Update();
+    mapper->SetTransformCoordinate(normCoords);
+
+    lineActor->SetMapper(mapper);
+    lineActor->GetMapper()->Update();
+}
+
+vtkTextProperty* Visualizer::buildStepLine(StepIndex step, vtkSmartPointer<vtkTextMapper> singleLineTextB, vtkSmartPointer<vtkTextProperty> singleLineTextProp, vtkSmartPointer<vtkNamedColors> colors, std::string color)
+{
+    std::string stepText = "Step " + std::to_string(step);
+    singleLineTextB->SetInput(stepText.c_str());
+    singleLineTextB->Update();
+    vtkTextProperty* textProp = singleLineTextB->GetTextProperty();
+    textProp->ShallowCopy(singleLineTextProp);
+    textProp->SetVerticalJustificationToBottom();
+    textProp->SetColor(colors->GetColor3d(color).GetData());
+    return textProp;
+}
+
+vtkNew<vtkActor2D> Visualizer::buildStepText(StepIndex step, int font_size, vtkSmartPointer<vtkNamedColors> colors, vtkSmartPointer<vtkTextProperty> singleLineTextProp, vtkSmartPointer<vtkTextMapper> stepLineTextMapper, vtkSmartPointer<vtkRenderer> renderer)
+{
+    singleLineTextProp->SetFontSize(font_size);
+    singleLineTextProp->SetFontFamilyToArial();
+    singleLineTextProp->BoldOn();
+    singleLineTextProp->ItalicOff();
+    singleLineTextProp->ShadowOff();
+
+    const std::string stringWithStep = "Step " + std::to_string(step);
+    stepLineTextMapper->SetInput(stringWithStep.c_str());
+    auto tprop = stepLineTextMapper->GetTextProperty();
+    tprop->ShallowCopy(singleLineTextProp);
+
+    tprop->SetVerticalJustificationToBottom();
+    tprop->SetColor(colors->GetColor3d("Red").GetData());
+
+    vtkNew<vtkActor2D> stepLineTextActor;
+    stepLineTextActor->SetMapper(stepLineTextMapper);
+    stepLineTextActor->GetPositionCoordinate()->SetCoordinateSystemToNormalizedDisplay();
+    stepLineTextActor->GetPositionCoordinate()->SetValue(0.05, 0.85);
+    renderer->AddActor2D(stepLineTextActor);
+    return stepLineTextActor;
 }

--- a/visualiser/Visualiser.cpp
+++ b/visualiser/Visualiser.cpp
@@ -1,5 +1,3 @@
-#include <ranges>
-
 #include "visualiser/Visualizer.hpp"
 
 
@@ -23,7 +21,7 @@ std::pair<int,int> VisualiserHelpers::getColumnAndRowFromLine(const std::string&
     return {nLocalCols, nLocalRows};
 }
 
-std::pair<int,int> VisualiserHelpers::calculateXYOffset(int node, int nNodeX, int nNodeY, const std::vector<int>& allLocalCols, const std::vector<int>& allLocalRows)
+std::pair<int,int> VisualiserHelpers::calculateXYOffset(NodeIndex node, int nNodeX, int nNodeY, const std::vector<int>& allLocalCols, const std::vector<int>& allLocalRows)
 {
     int offsetX = 0; //= //(node % nNodeX)*nLocalCols;//-this->borderSizeX;
     int offsetY = 0; //= //(node / nNodeX)*nLocalRows;//-this->borderSizeY;

--- a/visualiser/Visualiser.cpp
+++ b/visualiser/Visualiser.cpp
@@ -23,18 +23,6 @@ std::pair<int,int> VisualiserHelpers::getColumnAndRowFromLine(const std::string&
     return {nLocalCols, nLocalRows};
 }
 
-bool VisualiserHelpers::allNodesHaveEmptyData(const std::vector<int>& AlllocalCols, const std::vector<int>& AlllocalRows, int nodesCount)
-{
-    for (int node = 0; node < nodesCount; ++node)
-    {
-        if (AlllocalCols[node] > 0 || AlllocalRows[node] > 0)
-        {
-            return false;
-        }
-    }
-    return true;
-}
-
 std::pair<int,int> VisualiserHelpers::calculateXYOffset(int node, int nNodeX, int nNodeY, const std::vector<int>& allLocalCols, const std::vector<int>& allLocalRows)
 {
     int offsetX = 0; //= //(node % nNodeX)*nLocalCols;//-this->borderSizeX;

--- a/visualiser/Visualizer.hpp
+++ b/visualiser/Visualizer.hpp
@@ -1,12 +1,6 @@
 #pragma once
 
-#include <filesystem>
-#include <iostream>
 #include <string>
-#include <unordered_map>
-#include <format>
-#include <string_view>
-#include <vector>
 #include <vtkActor2D.h>
 #include <vtkCellArray.h>
 #include <vtkCoordinate.h>
@@ -25,71 +19,14 @@
 #include <vtkTextMapper.h>
 #include <vtkTextProperty.h>
 
-#include "Line.h"
 #include "OOpenCAL/base/Element.h" // rgb
-#include "visualiser/SettingParameter.h"
 #include "types.h" // StepIndex
 
-#ifndef __ssize_t_defined
-using ssize_t = intptr_t;
-#endif
+class Line;
 
-
-template <class T>
 class Visualizer
 {
-    std::vector<std::unordered_map<StepIndex, FilePosition>> hashMap;
-
 public:
-    void prepareHashMap(NodeIndex nNodeX, NodeIndex nNodeY)
-    {
-        hashMap.resize(nNodeX * nNodeY);
-    }
-
-    FilePosition getStepStartingPositionInFile(StepIndex step, NodeIndex node)
-    {
-        return hashMap.at(node).at(step);
-    }
-
-    /** @brief Opens the data file for a given simulation step and node.
-     *
-     * The function locates the correct file for the specified node (e.g. "ball3.txt", where 3 is node number),
-     * seeks to the byte position corresponding to the given simulation step in file,
-     * reads the first header line containing local grid dimensions (columns and rows),
-     * and returns an input file stream positioned right after that header.
-     *
-     * @param step         Simulation step number.
-     * @param fileName     Base file name (without node index or extension).
-     * @param node         Node index for which data should be opened.
-     * @param columnAndRow Output: number of local columns and rows read from header line.
-     *
-     * @return std::ifstream Stream ready for reading cell data of this node at given step.
-     * @throws std::runtime_error If the file cannot be opened, seek fails, or header is invalid. */
-    [[nodiscard]] std::ifstream readLocalColumnAndRowForStepFromFileReturningStream(StepIndex step, const std::string& fileName, NodeIndex node, ColumnAndRow& columnAndRow);
-
-    [[nodiscard]] ColumnAndRow readLocalColumnAndRowForStepFromFile(StepIndex step, const std::string& fileName, NodeIndex node);
-
-    template<class Matrix>
-    void readStageStateFromFilesForStep(Matrix& m, SettingParameter* sp, Line *lines);
-
-    /** @brief Loads data into hashMap from text files.
-     *
-     * Expected file format (each line):
-     *     <stepNumber:int> <positionInFile:long>
-     *
-     * Example:
-     *     0 37
-     *     1 32504
-     *     2 64971
-     *
-     * Each line must contain exactly two numbers separated by whitespace.
-     *
-     * @param nNodeX number of nodes along the X axis
-     * @param nNodeY number of nodes along the Y axis
-     * @param filename base filename (e.g., "ball"), for which nodes files are being read */
-    void readStepsOffsetsForAllNodesFromFiles(NodeIndex nNodeX, NodeIndex nNodeY, const std::string &filename);
-
-    /// visualising part:
     template<class Matrix>
     void drawWithVTK(/*const*/ Matrix& p, int nRows, int nCols, StepIndex step, Line *lines, vtkSmartPointer<vtkRenderer> renderer,vtkSmartPointer<vtkActor> gridActor);
     template<class Matrix>
@@ -100,183 +37,14 @@ public:
     vtkNew<vtkActor2D> buildStepText(StepIndex step, int font_size, vtkSmartPointer<vtkNamedColors> colors, vtkSmartPointer<vtkTextProperty> singleLineTextProp, vtkSmartPointer<vtkTextMapper> stepLineTextMapper, vtkSmartPointer<vtkRenderer> renderer);
 
 private:
-    std::pair<std::vector<StepIndex>, std::vector<StepIndex>> giveMeLocalColsAndRowsForAllSteps(StepIndex step, int nNodeX, int nNodeY, const std::string& fileName);
+    template<class Matrix>
+    void buidColor(vtkLookupTable* lut, int nCols, int nRows, Matrix& p);
 };
 
-namespace VisualiserHelpers /// functions which are not templates
-{
-[[nodiscard]] inline std::string giveMeFileName(const std::string& fileName, NodeIndex node)
-{
-    return std::format("{}{}.txt", fileName, node);
-}
-[[nodiscard]] inline std::string giveMeFileNameIndex(const std::string &fileName, NodeIndex node)
-{
-    return std::format("{}{}_index.txt", fileName, node);
-}
-
-ColumnAndRow getColumnAndRowFromLine(const std::string& line);
-
-std::pair<int,int> calculateXYOffset(NodeIndex node, int nNodeX, int nNodeY, const std::vector<int>& allLocalCols, const std::vector<int>& allLocalRows);
-}
 ////////////////////////////////////////////////////////////////////
 
-template <class T>
-ColumnAndRow Visualizer<T>::readLocalColumnAndRowForStepFromFile(StepIndex step, const std::string& fileName, NodeIndex node)
-{
-    ColumnAndRow columnAndRow;
-    std::ifstream file = readLocalColumnAndRowForStepFromFileReturningStream(step, fileName, node, columnAndRow);
-    return columnAndRow;
-}
-template <class T>
-std::ifstream Visualizer<T>::readLocalColumnAndRowForStepFromFileReturningStream(StepIndex step, const std::string& fileName, NodeIndex node, ColumnAndRow &columnAndRow)
-{
-    const auto fileNameTmp = VisualiserHelpers::giveMeFileName(fileName, node);
-
-    std::ifstream file(fileNameTmp);
-    if (! file.is_open())
-    {
-        throw std::runtime_error(std::format("Can't read '{}' in {} function", fileNameTmp, __func__));
-    }
-
-    const auto fPos = getStepStartingPositionInFile(step, node);
-    file.seekg(fPos);
-    if (! file)
-    {
-        throw std::runtime_error(std::format("Seek failed in '{}' at position {}", fileNameTmp, fPos));
-    }
-
-    std::string line;
-    if (! std::getline(file, line))
-    {
-        throw std::runtime_error(std::format("Failed to read line from '{}' at position {}", fileNameTmp, fPos));
-    }
-
-    columnAndRow = VisualiserHelpers::getColumnAndRowFromLine(line);
-    return file;
-}
-
-template<class T>
-template<class Matrix>
-void Visualizer<T>::readStageStateFromFilesForStep(Matrix& m, SettingParameter* sp, Line *lines)
-{
-    const auto [allLocalCols, allLocalRows] = giveMeLocalColsAndRowsForAllSteps(sp->step, sp->nNodeX, sp->nNodeY, sp->outputFileName);
-
-    bool startStepDone = false;
-
-    constexpr std::size_t numbersPerLine = 10'000;
-    const std::size_t lineBufferSize = (log10(UINT_MAX) + 2) * numbersPerLine;
-    std::string line;
-    line.reserve(lineBufferSize); /// for speedup to avoid realocations
-
-    for (NodeIndex node = 0; node < sp->nNodeX * sp->nNodeY; ++node)
-    {
-        const auto [offsetX, offsetY] = VisualiserHelpers::calculateXYOffset(node, sp->nNodeX, sp->nNodeY, allLocalCols, allLocalRows);
-
-        ColumnAndRow columnAndRow;
-        std::ifstream fp = readLocalColumnAndRowForStepFromFileReturningStream(sp->step, sp->outputFileName, node, columnAndRow);
-        if (! fp)
-            throw std::runtime_error("Cannot open file for node " + std::to_string(node));
-
-        /// introducing big buffer for reading (for speed up)
-        static thread_local char fileBuffer[1 << 16];
-        fp.rdbuf()->pubsetbuf(fileBuffer, sizeof(fileBuffer));
-
-        lines[node * 2]     = Line(offsetX, offsetY, offsetX + columnAndRow.column, offsetY);
-        lines[node * 2 + 1] = Line(offsetX, offsetY, offsetX, offsetY + columnAndRow.row);
-
-        for (int row = 0; row < columnAndRow.row; ++row)
-        {
-            if (! std::getline(fp, line))
-            {
-                const auto fileNameTmp = VisualiserHelpers::giveMeFileName(sp->outputFileName, node);
-                throw std::runtime_error("Error when reading entire line of file " + fileNameTmp);
-            }
-
-            std::replace(begin(line), end(line), ' ', '\0'); /// this is faster than using std::ranges::replace
-
-            /// Moving through tokens (token are characters ended with '0')
-            char* currentTokenPtr = line.data();
-            for (int col = 0; col < columnAndRow.column && *currentTokenPtr; ++col)
-            {
-                if (! startStepDone) [[unlikely]]
-                {
-                    m[row + offsetY][col + offsetX].T::startStep(sp->step);
-                    startStepDone = true;
-                }
-
-                m[row + offsetY][col + offsetX].T::composeElement(currentTokenPtr);
-
-                /// go to another token
-                while (*currentTokenPtr)
-                    ++currentTokenPtr;
-                ++currentTokenPtr; /// skip '\0'
-            }
-        }
-    }
-}
-template<class T>
-std::pair<std::vector<StepIndex>, std::vector<StepIndex>> Visualizer<T>::giveMeLocalColsAndRowsForAllSteps(StepIndex step, int nNodeX, int nNodeY, const std::string& fileName)
-{
-    const auto nodesCount = nNodeX * nNodeY;
-    std::vector<StepIndex> allLocalCols{nodesCount}, allLocalRows{nodesCount};
-    allLocalCols.resize(nodesCount);
-    allLocalRows.resize(nodesCount);
-
-    for (NodeIndex node = 0; node < nodesCount; node++)
-    {
-        auto [nLocalCols, nLocalRows] = readLocalColumnAndRowForStepFromFile(step, fileName, node);
-
-        allLocalCols[node] = nLocalCols;
-        allLocalRows[node] = nLocalRows;
-    }
-    return {allLocalCols, allLocalRows};
-}
-
-template <class T>
-void Visualizer<T>::readStepsOffsetsForAllNodesFromFiles(NodeIndex nNodeX, NodeIndex nNodeY, const std::string& filename)
-{
-    const auto totalNodes = nNodeX * nNodeY;
-    for (NodeIndex node = 0; node < totalNodes; ++node)
-    {
-        const auto fileNameIndex = VisualiserHelpers::giveMeFileNameIndex(filename, node);
-        std::cout << "Reading file: " << fileNameIndex << '\n';
-
-        if (! std::filesystem::exists(fileNameIndex))
-        {
-            throw std::runtime_error("File not found: " + fileNameIndex);
-        }
-
-        std::ifstream file(fileNameIndex);
-        if (! file)
-        {
-            throw std::runtime_error("Cannot open file: " + fileNameIndex);
-        }
-
-        while (true)
-        {
-            StepIndex stepNumber;
-            FilePosition positionInFile;
-
-            if (! (file >> stepNumber >> positionInFile))
-            { /// enters here if reading error
-                if (file.eof())
-                    break;
-                else
-                    throw std::runtime_error("Invalid line format in file: " + fileNameIndex);
-            }
-
-            const auto [it, inserted] = hashMap[node].emplace(stepNumber, positionInFile);
-            if (! inserted)
-            {
-                std::cerr << std::format("Duplicate stepNumber {} found in file '{}' (node {})", stepNumber, fileNameIndex, node) << std::endl;
-            }
-        }
-    }
-}
-
-template <class T>
 template <class Matrix>
-void Visualizer<T>::drawWithVTK(/*const*/ Matrix& p, int nRows, int nCols, StepIndex step, Line *lines, vtkSmartPointer<vtkRenderer> renderer, vtkSmartPointer<vtkActor> gridActor)
+void Visualizer::drawWithVTK(/*const*/ Matrix& p, int nRows, int nCols, StepIndex step, Line *lines, vtkSmartPointer<vtkRenderer> renderer, vtkSmartPointer<vtkActor> gridActor)
 {
     const auto numberOfPoints = nRows * nCols;
     vtkNew<vtkDoubleArray> pointValues;
@@ -315,9 +83,8 @@ void Visualizer<T>::drawWithVTK(/*const*/ Matrix& p, int nRows, int nCols, StepI
     renderer->AddActor(gridActor);
 }
 
-template <class T>
 template <class Matrix>
-void Visualizer<T>::refreshWindowsVTK(/*const*/ Matrix& p, int nRows, int nCols, StepIndex step, Line *lines, int dimLines, vtkSmartPointer<vtkActor> gridActor)
+void Visualizer::refreshWindowsVTK(/*const*/ Matrix& p, int nRows, int nCols, StepIndex step, Line *lines, int dimLines, vtkSmartPointer<vtkActor> gridActor)
 {
     if (vtkLookupTable* lut = dynamic_cast<vtkLookupTable*>(gridActor->GetMapper()->GetLookupTable()))
     {
@@ -329,110 +96,8 @@ void Visualizer<T>::refreshWindowsVTK(/*const*/ Matrix& p, int nRows, int nCols,
         throw std::runtime_error("Invalid dynamic cast!");
 }
 
-template <class T>
-void Visualizer<T>::buildLoadBalanceLine(Line *lines, int dimLines,int nCols, int nRows, vtkSmartPointer<vtkPoints> pts, vtkSmartPointer<vtkCellArray> cellLines, vtkSmartPointer<vtkPolyData> grid, vtkSmartPointer<vtkNamedColors> colors, vtkSmartPointer<vtkRenderer> renderer,vtkSmartPointer<vtkActor2D> actorBuildLine)
-{
-    for (int i = 0; i < dimLines; i++)
-    {
-        std::cout << "Line (" << lines[i].x1 << ", " << lines[i].y1 << ") -> (" <<lines[i].x2 << ", " <<lines[i].y2 << ")" << std::endl;
-        pts->InsertNextPoint(lines[i].x1 * 1, nCols-1-lines[i].y1 * 1, 0.0);
-        pts->InsertNextPoint(lines[i].x2 * 1, nCols-1-lines[i].y2 * 1, 0.0);
-        cellLines->InsertNextCell(2);
-        cellLines->InsertCellPoint(i*2);
-        cellLines->InsertCellPoint(i*2+1);
-    }
-
-    grid->SetPoints(pts);
-    grid->SetLines(cellLines);
-    // Set up the coordinate system.
-    vtkNew<vtkCoordinate> normCoords;
-    normCoords->SetCoordinateSystemToWorld();
-
-    vtkNew<vtkPolyDataMapper2D> mapper;
-    mapper->SetInputData(grid);
-    mapper->Update();
-    mapper->SetTransformCoordinate(normCoords);
-
-    actorBuildLine->SetMapper(mapper);
-    actorBuildLine->GetMapper()->Update();
-    actorBuildLine->GetProperty()->SetColor(colors->GetColor3d("Red").GetData());
-   // actorBuildLine->GetProperty()->SetLineWidth(1.5);
-    renderer->AddActor2D(actorBuildLine);
-}
-
-template <class T>
-void Visualizer<T>::refreshBuildLoadBalanceLine(Line *lines, int dimLines,int nCols,int nRows, vtkActor2D* lineActor,vtkSmartPointer<vtkNamedColors> colors)
-{
-    vtkPolyDataMapper2D* mapper = (vtkPolyDataMapper2D*) lineActor->GetMapper();
-    mapper->Update();
-    vtkNew<vtkPolyData> grid;
-    vtkNew<vtkPoints> pts;
-    vtkNew<vtkCellArray> cellLines;
-
-    for (int i = 0; i < dimLines; i++)
-    {
-        pts->InsertNextPoint((lines[i].x1 * 1), ( nCols-1-lines[i].y1 * 1), 0.0);
-        pts->InsertNextPoint((lines[i].x2 * 1), ( nCols-1-lines[i].y2 * 1), 0.0);
-        cellLines->InsertNextCell(2);
-        cellLines->InsertCellPoint(i*2);
-        cellLines->InsertCellPoint(i*2+1);
-    }
-
-    grid->SetPoints(pts);
-    grid->SetLines(cellLines);
-    // Set up the coordinate system.
-    vtkNew<vtkCoordinate> normCoords;
-    normCoords->SetCoordinateSystemToWorld();
-
-    mapper->SetInputData(grid);
-    mapper->Update();
-    mapper->SetTransformCoordinate(normCoords);
-    
-    lineActor->SetMapper(mapper);
-    lineActor->GetMapper()->Update();
-}
-
-template <class T>
-vtkTextProperty* Visualizer<T>::buildStepLine(StepIndex step, vtkSmartPointer<vtkTextMapper> singleLineTextB, vtkSmartPointer<vtkTextProperty> singleLineTextProp, vtkSmartPointer<vtkNamedColors> colors, std::string color)
-{
-    std::string stepText = "Step " + std::to_string(step);
-    singleLineTextB->SetInput(stepText.c_str());
-    singleLineTextB->Update();
-    vtkTextProperty* tprop = singleLineTextB->GetTextProperty();
-    tprop->ShallowCopy(singleLineTextProp);
-    tprop->SetVerticalJustificationToBottom();
-    tprop->SetColor(colors->GetColor3d(color).GetData());
-    return tprop;
-}
-
-
-template <class T>
-vtkNew<vtkActor2D> Visualizer<T>::buildStepText(StepIndex step, int font_size, vtkSmartPointer<vtkNamedColors> colors, vtkSmartPointer<vtkTextProperty> singleLineTextProp, vtkSmartPointer<vtkTextMapper> stepLineTextMapper, vtkSmartPointer<vtkRenderer> renderer)
-{
-    singleLineTextProp->SetFontSize(font_size);
-    singleLineTextProp->SetFontFamilyToArial();
-    singleLineTextProp->BoldOn();
-    singleLineTextProp->ItalicOff();
-    singleLineTextProp->ShadowOff();
-
-    const std::string stringWithStep = "Step " + std::to_string(step);
-    stepLineTextMapper->SetInput(stringWithStep.c_str());
-    auto tprop = stepLineTextMapper->GetTextProperty();
-    tprop->ShallowCopy(singleLineTextProp);
-
-    tprop->SetVerticalJustificationToBottom();
-    tprop->SetColor(colors->GetColor3d("Red").GetData());
-
-    vtkNew<vtkActor2D> stepLineTextActor;
-    stepLineTextActor->SetMapper(stepLineTextMapper);
-    stepLineTextActor->GetPositionCoordinate()->SetCoordinateSystemToNormalizedDisplay();
-    stepLineTextActor->GetPositionCoordinate()->SetValue(0.05, 0.85);
-    renderer->AddActor2D(stepLineTextActor);
-    return stepLineTextActor;
-}
-
 template <class Matrix>
-void buidColor(vtkLookupTable* lut, int nCols, int nRows, Matrix& p)
+void Visualizer::buidColor(vtkLookupTable* lut, int nCols, int nRows, Matrix& p)
 {
     for (int r = 0; r < nRows; ++r)
     {

--- a/visualiserProxy/SceneWidgetVisualizerProxy.h
+++ b/visualiserProxy/SceneWidgetVisualizerProxy.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include "visualiser/Visualizer.hpp"
+#include "ModelReader.hpp"
 
 template<typename Cell>
 struct SceneWidgetVisualizerTemplate
 {
-    Visualizer<Cell> vis;
+    Visualizer visualiser;
+    ModelReader<Cell> modelReader;
 
     std::vector<std::vector<Cell>> p;
 

--- a/widgets/SceneWidget.cpp
+++ b/widgets/SceneWidget.cpp
@@ -118,7 +118,7 @@ void SceneWidget::setupSettingParameters(const std::string & configFilename)
 
 void SceneWidget::setupVtkScene()
 {
-    sceneWidgetVisualizerProxy->modelReader.prepareHashMap(settingParameter->nNodeX, settingParameter->nNodeY);
+    sceneWidgetVisualizerProxy->modelReader.prepareStage(settingParameter->nNodeX, settingParameter->nNodeY);
 
     renderWindow()->AddRenderer(settingRenderParameter->m_renderer);
     interactor()->SetRenderWindow(renderWindow());

--- a/widgets/SceneWidget.cpp
+++ b/widgets/SceneWidget.cpp
@@ -84,8 +84,8 @@ void SceneWidget::readSettingsFromConfigFile(const std::string &filename)
         ConfigCategory* generalContext = config.getConfigCategory("GENERAL");
         const std::string outputFileNameFromCfg = generalContext->getConfigParameter("output_file_name")->getValue<std::string>();
         settingParameter->outputFileName = prepareOutputFileName(filename, outputFileNameFromCfg);
-        settingParameter->dimX = generalContext->getConfigParameter("number_of_columns")->getValue<int>();
-        settingParameter->dimY = generalContext->getConfigParameter("number_of_rows")->getValue<int>();
+        settingParameter->numberOfColumnX = generalContext->getConfigParameter("number_of_columns")->getValue<int>();
+        settingParameter->numberOfRowsY = generalContext->getConfigParameter("number_of_rows")->getValue<int>();
         settingParameter->nsteps = generalContext->getConfigParameter("number_steps")->getValue<int>();
     }
 
@@ -109,7 +109,7 @@ void SceneWidget::setupSettingParameters(const std::string & configFilename)
     settingParameter->firstTime = true;
     settingParameter->insertAction = false;
 
-    sceneWidgetVisualizerProxy->initMatrix(settingParameter->dimX, settingParameter->dimY);
+    sceneWidgetVisualizerProxy->initMatrix(settingParameter->numberOfColumnX, settingParameter->numberOfRowsY);
 
     settingRenderParameter->m_renderer->SetBackground(settingRenderParameter->colors->GetColor3d("Silver").GetData());
 
@@ -123,7 +123,7 @@ void SceneWidget::setupVtkScene()
     renderWindow()->AddRenderer(settingRenderParameter->m_renderer);
     interactor()->SetRenderWindow(renderWindow());
 
-    renderWindow()->SetSize(settingParameter->dimX, settingParameter->dimY + 10);
+    renderWindow()->SetSize(settingParameter->numberOfColumnX, settingParameter->numberOfRowsY + 10);
 
     /// An interactor with this style blocks rotation but not zoom.
     /// Use nullptr in SetInteractorStyle to block everything.
@@ -149,13 +149,13 @@ void SceneWidget::renderVtkScene()
     sceneWidgetVisualizerProxy->vis.readStageStateFromFilesForStep(sceneWidgetVisualizerProxy->p, settingParameter.get(), &lines[0]);
     DEBUG << "DEBUG: readStageStateFromFilesForStep completed" << endl;
 
-    sceneWidgetVisualizerProxy->vis.drawWithVTK(sceneWidgetVisualizerProxy->p, settingParameter->dimY, settingParameter->dimX, settingParameter->step, &lines[0], settingRenderParameter->m_renderer, gridActor);
+    sceneWidgetVisualizerProxy->vis.drawWithVTK(sceneWidgetVisualizerProxy->p, settingParameter->numberOfRowsY, settingParameter->numberOfColumnX, settingParameter->step, &lines[0], settingRenderParameter->m_renderer, gridActor);
     DEBUG << "DEBUG: drawWithVTK completed" << endl;
 
     vtkNew<vtkCellArray> cellLines;
     vtkNew<vtkPoints> pts;
     vtkNew<vtkPolyData> grid;
-    sceneWidgetVisualizerProxy->vis.buildLoadBalanceLine(&lines[0], settingParameter->numberOfLines, settingParameter->dimY+1, settingParameter->dimX+1, pts, cellLines, grid,settingRenderParameter->colors,settingRenderParameter->m_renderer,actorBuildLine);
+    sceneWidgetVisualizerProxy->vis.buildLoadBalanceLine(&lines[0], settingParameter->numberOfLines, settingParameter->numberOfRowsY+1, settingParameter->numberOfColumnX+1, pts, cellLines, grid,settingRenderParameter->colors,settingRenderParameter->m_renderer,actorBuildLine);
     DEBUG << "DEBUG: buildLoadBalanceLine completed" << endl;
 
     sceneWidgetVisualizerProxy->vis.buildStepText(settingParameter->step, settingParameter->font_size, settingRenderParameter->colors, singleLineTextPropStep, singleLineTextStep, settingRenderParameter->m_renderer);
@@ -295,8 +295,8 @@ void SceneWidget::updateVisualization()
 
     sceneWidgetVisualizerProxy->vis.refreshWindowsVTK(
         sceneWidgetVisualizerProxy->p,
-        settingParameter->dimY,
-        settingParameter->dimX,
+        settingParameter->numberOfRowsY,
+        settingParameter->numberOfColumnX,
         settingParameter->step,
         &lines[0],
         settingParameter->numberOfLines,
@@ -313,8 +313,8 @@ void SceneWidget::updateVisualization()
         sceneWidgetVisualizerProxy->vis.refreshBuildLoadBalanceLine(
             &lines[0], 
             settingParameter->numberOfLines, 
-            settingParameter->dimY + 1, 
-            settingParameter->dimX + 1, 
+            settingParameter->numberOfRowsY + 1,
+            settingParameter->numberOfColumnX + 1,
             actorBuildLine, 
             settingRenderParameter->colors
         );

--- a/widgets/SceneWidget.cpp
+++ b/widgets/SceneWidget.cpp
@@ -62,14 +62,14 @@ void SceneWidget::enableToolTipWhenMouseAboveWidget()
 SceneWidget::~SceneWidget() = default;
 
 
-void SceneWidget::addVisualizer(const std::string &filename)
+void SceneWidget::addVisualizer(const std::string &filename, int stepNumber)
 {
     if (! std::filesystem::exists(filename))
     {
         throw std::invalid_argument("File '"s + filename + "' does not exist!");
     }
 
-    setupSettingParameters(filename);
+    setupSettingParameters(filename, stepNumber);
 
     setupVtkScene();
 
@@ -99,12 +99,12 @@ void SceneWidget::readSettingsFromConfigFile(const std::string &filename)
     }
 }
 
-void SceneWidget::setupSettingParameters(const std::string & configFilename)
+void SceneWidget::setupSettingParameters(const std::string & configFilename, int stepNumber)
 {
     readSettingsFromConfigFile(configFilename);
 
     settingParameter->numberOfLines = 2 * (settingParameter->nNodeX * settingParameter->nNodeY);
-    settingParameter->step = 1;
+    settingParameter->step = stepNumber;
     settingParameter->changed = false;
     settingParameter->firstTime = true;
     settingParameter->insertAction = false;

--- a/widgets/SceneWidget.cpp
+++ b/widgets/SceneWidget.cpp
@@ -275,7 +275,7 @@ void SceneWidget::showToolTip()
                       2000); // Show for 2 seconds
 }
 
-void SceneWidget::selectedStepParameter(int stepNumber)
+void SceneWidget::selectedStepParameter(StepIndex stepNumber)
 {
     settingParameter->step = stepNumber;
     settingParameter->changed = true;

--- a/widgets/SceneWidget.cpp
+++ b/widgets/SceneWidget.cpp
@@ -174,8 +174,6 @@ void SceneWidget::keypressCallbackFunction(vtkObject* caller, long unsigned int 
     SceneWidget* sw = static_cast<SceneWidget*>(clientData);
     SettingParameter* sp = sw->settingParameter.get();
 
-    SceneWidgetVisualizerProxy* visualiserProxy = sw->sceneWidgetVisualizerProxy.get();
-
     if (keyPressed == "Up")
     {
         if (sp->step < sp->nsteps * 2)

--- a/widgets/SceneWidget.cpp
+++ b/widgets/SceneWidget.cpp
@@ -118,7 +118,7 @@ void SceneWidget::setupSettingParameters(const std::string & configFilename)
 
 void SceneWidget::setupVtkScene()
 {
-    sceneWidgetVisualizerProxy->vis.prepareHashMap(settingParameter->nNodeX, settingParameter->nNodeY);
+    sceneWidgetVisualizerProxy->modelReader.prepareHashMap(settingParameter->nNodeX, settingParameter->nNodeY);
 
     renderWindow()->AddRenderer(settingRenderParameter->m_renderer);
     interactor()->SetRenderWindow(renderWindow());
@@ -141,24 +141,24 @@ void SceneWidget::setupVtkScene()
 void SceneWidget::renderVtkScene()
 {
     DEBUG << "DEBUG: Starting " << __FUNCTION__ << endl;
-    sceneWidgetVisualizerProxy->vis.readStepsOffsetsForAllNodesFromFiles(settingParameter->nNodeX, settingParameter->nNodeY, settingParameter->outputFileName);
+    sceneWidgetVisualizerProxy->modelReader.readStepsOffsetsForAllNodesFromFiles(settingParameter->nNodeX, settingParameter->nNodeY, settingParameter->outputFileName);
     DEBUG << "DEBUG: Hashmap loaded successfully" << endl;
 
     std::vector<Line> lines(settingParameter->numberOfLines);
 
-    sceneWidgetVisualizerProxy->vis.readStageStateFromFilesForStep(sceneWidgetVisualizerProxy->p, settingParameter.get(), &lines[0]);
+    sceneWidgetVisualizerProxy->modelReader.readStageStateFromFilesForStep(sceneWidgetVisualizerProxy->p, settingParameter.get(), &lines[0]);
     DEBUG << "DEBUG: readStageStateFromFilesForStep completed" << endl;
 
-    sceneWidgetVisualizerProxy->vis.drawWithVTK(sceneWidgetVisualizerProxy->p, settingParameter->numberOfRowsY, settingParameter->numberOfColumnX, settingParameter->step, &lines[0], settingRenderParameter->m_renderer, gridActor);
+    sceneWidgetVisualizerProxy->visualiser.drawWithVTK(sceneWidgetVisualizerProxy->p, settingParameter->numberOfRowsY, settingParameter->numberOfColumnX, settingParameter->step, &lines[0], settingRenderParameter->m_renderer, gridActor);
     DEBUG << "DEBUG: drawWithVTK completed" << endl;
 
     vtkNew<vtkCellArray> cellLines;
     vtkNew<vtkPoints> pts;
     vtkNew<vtkPolyData> grid;
-    sceneWidgetVisualizerProxy->vis.buildLoadBalanceLine(&lines[0], settingParameter->numberOfLines, settingParameter->numberOfRowsY+1, settingParameter->numberOfColumnX+1, pts, cellLines, grid,settingRenderParameter->colors,settingRenderParameter->m_renderer,actorBuildLine);
+    sceneWidgetVisualizerProxy->visualiser.buildLoadBalanceLine(&lines[0], settingParameter->numberOfLines, settingParameter->numberOfRowsY+1, settingParameter->numberOfColumnX+1, pts, cellLines, grid,settingRenderParameter->colors,settingRenderParameter->m_renderer,actorBuildLine);
     DEBUG << "DEBUG: buildLoadBalanceLine completed" << endl;
 
-    sceneWidgetVisualizerProxy->vis.buildStepText(settingParameter->step, settingParameter->font_size, settingRenderParameter->colors, singleLineTextPropStep, singleLineTextStep, settingRenderParameter->m_renderer);
+    sceneWidgetVisualizerProxy->visualiser.buildStepText(settingParameter->step, settingParameter->font_size, settingRenderParameter->colors, singleLineTextPropStep, singleLineTextStep, settingRenderParameter->m_renderer);
 
     // Render
     renderWindow()->Render();
@@ -285,13 +285,13 @@ void SceneWidget::updateVisualization()
 {
     std::vector<Line> lines(settingParameter->numberOfLines);
 
-    sceneWidgetVisualizerProxy->vis.readStageStateFromFilesForStep(
+    sceneWidgetVisualizerProxy->modelReader.readStageStateFromFilesForStep(
         sceneWidgetVisualizerProxy->p,
         settingParameter.get(),
         &lines[0]
     );
 
-    sceneWidgetVisualizerProxy->vis.refreshWindowsVTK(
+    sceneWidgetVisualizerProxy->visualiser.refreshWindowsVTK(
         sceneWidgetVisualizerProxy->p,
         settingParameter->numberOfRowsY,
         settingParameter->numberOfColumnX,
@@ -308,7 +308,7 @@ void SceneWidget::updateVisualization()
 
     if (settingParameter->numberOfLines > 0)
     {
-        sceneWidgetVisualizerProxy->vis.refreshBuildLoadBalanceLine(
+        sceneWidgetVisualizerProxy->visualiser.refreshBuildLoadBalanceLine(
             &lines[0], 
             settingParameter->numberOfLines, 
             settingParameter->numberOfRowsY + 1,
@@ -319,7 +319,7 @@ void SceneWidget::updateVisualization()
     }
 
     const std::string stepLineColor{"red"};
-    sceneWidgetVisualizerProxy->vis.buildStepLine(
+    sceneWidgetVisualizerProxy->visualiser.buildStepLine(
         settingParameter->step, 
         singleLineTextStep, 
         singleLineTextPropStep, 

--- a/widgets/SceneWidget.h
+++ b/widgets/SceneWidget.h
@@ -22,7 +22,7 @@ public:
     explicit SceneWidget(QWidget* parent);
     ~SceneWidget();
 
-    void addVisualizer(const string &filename);
+    void addVisualizer(const string &filename, int stepNumber);
 
     void selectedStepParameter(StepIndex stepNumber);
 
@@ -57,7 +57,7 @@ protected:
     void readSettingsFromConfigFile(const std::string &filename);
 
     void setupVtkScene();
-    void setupSettingParameters(const std::string & configFilename);
+    void setupSettingParameters(const std::string & configFilename, int stepNumber);
 
 private:
     std::unique_ptr<SceneWidgetVisualizerProxy> sceneWidgetVisualizerProxy;

--- a/widgets/SceneWidget.h
+++ b/widgets/SceneWidget.h
@@ -24,7 +24,7 @@ public:
 
     void addVisualizer(const string &filename);
 
-    void selectedStepParameter(int stepNumber);
+    void selectedStepParameter(StepIndex stepNumber);
 
     const SettingParameter* getSettingParameter() const
     {
@@ -34,7 +34,7 @@ public:
     static void keypressCallbackFunction(vtkObject* caller, long unsigned int eventId, void* clientData, void* callData);
 
 signals:
-    void changedStepNumberWithKeyboardKeys(int stepNumber);
+    void changedStepNumberWithKeyboardKeys(StepIndex stepNumber);
 
 public slots:
     void increaseCountUp();


### PR DESCRIPTION
# Changes:
1. Extracted `ModelReader<Cell>` from `Visualiser<Cell>`, which is not template
2. Removed unused methods
3. Added SkibBackwardButton to GUI
4. Renamed variables in `SettingParameter` to have names compatible with config file
5. Introduced simple types to imporove readilibity: `StepIndex`, `NodeIndex`, `FilePosition`, `ColumnAndRow`